### PR TITLE
Rename `create_crop_hash` to `update_crop_hash`

### DIFF
--- a/src/wp-includes/class-wp-image-editor.php
+++ b/src/wp-includes/class-wp-image-editor.php
@@ -242,7 +242,7 @@ abstract class WP_Image_Editor {
 	 * @param string $hash
 	 * @return true
 	 */
-	protected function create_crop_hash( $hash = null ) {
+	protected function update_crop_hash( $hash = null ) {
 		$this->hash = $hash;
 		return true;
 	}


### PR DESCRIPTION
Patches failed on 6.4.
Updated patch for WP 6.4.

Trac ticket: [`add_image_sizes` does not create the "crop position" versions of the image](https://core.trac.wordpress.org/ticket/40370)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
